### PR TITLE
Add support for stateful decoder conformance tests with fluster

### DIFF
--- a/config/core/test-configs.yaml
+++ b/config/core/test-configs.yaml
@@ -654,7 +654,8 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'AV1-TEST-VECTORS'
-      decoder: 'GStreamer-AV1-V4L2SL-Gst1.0'
+      decoders:
+        - 'GStreamer-AV1-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -665,7 +666,9 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'JVT-AVC_V1'
-      decoder: 'GStreamer-H.264-V4L2SL-Gst1.0'
+      decoders:
+        - 'GStreamer-H.264-V4L2-Gst1.0'
+        - 'GStreamer-H.264-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -676,7 +679,9 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'JCT-VC-HEVC-V1'
-      decoder: 'GStreamer-H.265-V4L2SL-Gst1.0'
+      decoders:
+        - 'GStreamer-H.265-V4L2-Gst1.0'
+        - 'GStreamer-H.265-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -687,7 +692,9 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'VP8-TEST-VECTORS'
-      decoder: 'GStreamer-VP8-V4L2SL-Gst1.0'
+      decoders:
+        - 'GStreamer-VP8-V4L2-Gst1.0'
+        - 'GStreamer-VP8-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}
@@ -698,7 +705,8 @@ test_plans:
     params:
       job_timeout: '30'
       testsuite: 'VP9-TEST-VECTORS'
-      decoder: 'GStreamer-VP9-V4L2SL-Gst1.0'
+      decoders:
+        - 'GStreamer-VP9-V4L2SL-Gst1.0'
       videodec_parallel_jobs: '1'
     filters:
       - regex: {'tree': '(next|mainline|media)'}

--- a/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
+++ b/config/lava/v4l2-decoder-conformance/v4l2-decoder-conformance.jinja2
@@ -1,8 +1,12 @@
 {%- if testsuite -%}
     {% set testsuite_arg = "-ts " + testsuite %}
 {%- endif -%}
-{%- if decoder -%}
-    {% set decoder_arg = "-d " + decoder|string %}
+{%- if decoders -%}
+    {%- set decoder_list = [ ] -%}
+    {%- for decoder in decoders -%}
+        {{ decoder_list.append(decoder) or "" }}
+    {%- endfor -%}
+    {%- set decoders_arg = "-d " + decoder_list|join(" ") -%}
 {%- endif -%}
 {%- if videodec_timeout -%}
     {% set videodec_timeout_arg = "-t " + videodec_timeout|string %}
@@ -25,7 +29,7 @@
           - functional
         run:
           steps:
-          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ decoder_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
+          - python3 /usr/bin/fluster_parser.py {{ testsuite_arg }} {{ decoders_arg }} {{ videodec_timeout_arg }} {{ videodec_parallel_jobs_arg }}
       from: inline
       name: {{ plan }}
       path: inline/{{ plan }}.yaml

--- a/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
+++ b/config/rootfs/debos/overlays/fluster/usr/bin/fluster_parser.py
@@ -77,8 +77,8 @@ def _run_fluster(test_suite=None, timeout=None, jobs=None, decoders=None):
         cmd.extend(['-t', timeout])
     if jobs:
         cmd.extend(['-j', jobs])
-    if decoders:
-        cmd.extend(['-d', decoders])
+    for index, dec in enumerate(decoders):
+        cmd.extend(['-d', dec] if not index else [dec])
 
     subprocess.run(cmd, cwd=FLUSTER_PATH, check=False)
 
@@ -127,6 +127,6 @@ if __name__ == '__main__':
     parser.add_argument('-ts', '--test-suite')
     parser.add_argument('-t', '--timeout')
     parser.add_argument('-j', '--jobs')
-    parser.add_argument('-d', '--decoders')
+    parser.add_argument('-d', '--decoders', nargs='+')
     args = parser.parse_args()
     sys.exit(main(args))

--- a/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
+++ b/config/rootfs/debos/scripts/bullseye-gst-fluster.sh
@@ -77,6 +77,7 @@ meson setup build \
 	-Dgst-plugins-base:typefind=enabled \
 	-Dgst-plugins-base:videoconvertscale=enabled \
 	-Dgst-plugins-good:matroska=enabled \
+	-Dgst-plugins-good:v4l2=enabled \
 	-Dtools=enabled \
 	-Ddevtools=disabled \
 	-Dges=disabled \


### PR DESCRIPTION
Add support for fluster conformance tests on stateful decoders, found in `trogdor` Chromebooks.